### PR TITLE
Fix Android build with NDK 26

### DIFF
--- a/external/jpeg-9/jmem-android.c
+++ b/external/jpeg-9/jmem-android.c
@@ -15,6 +15,8 @@
  */
 
 #define JPEG_INTERNALS
+
+#include <unistd.h>
 #include "jinclude.h"
 #include "jpeglib.h"
 #include "jmemsys.h"		/* import the system-dependent declarations */


### PR DESCRIPTION
This change is required to build the Android port with NDK 26.